### PR TITLE
fix: react and vue integrations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -149,9 +149,6 @@ export default function createIntegration(args?: Options): AstroIntegration {
 							(vite.resolve.alias as Record<string, string>)[alias.find] = alias.replacement;
 						}
 					}
-					vite.ssr = {
-						noExternal: COMPATIBLE_NODE_MODULES,
-					};
 
 					if (Array.isArray(vite.build.rollupOptions.external)) {
 						vite.build.rollupOptions.external.push(DENO_IMPORTS_SHIM);


### PR DESCRIPTION
This allows the deno integration to be used alongisde `@astrojs/react` 2.3+ and `@astrojs/vue`.