### PR TITLE
fix: shim replacement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,10 @@ export default function createIntegration(args?: Options): AstroIntegration {
           fs.writeFileSync(
             pth,
             contents.replace(
-              new RegExp(String.raw`import \{ serveFile, fromFileUrl \} from ['"]${DENO_IMPORTS_SHIM}['"];`),
+              new RegExp(
+                String
+                  .raw`import \{ serveFile, fromFileUrl \} from ['"]${DENO_IMPORTS_SHIM}['"];`,
+              ),
               DENO_IMPORTS,
             ),
           );

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
           fs.writeFileSync(
             pth,
             contents.replace(
-              `import { serveFile, fromFileUrl } from '${DENO_IMPORTS_SHIM}';`,
+              new RegExp(String.raw`import \{ serveFile, fromFileUrl \} from ['"]${DENO_IMPORTS_SHIM}['"];`),
               DENO_IMPORTS,
             ),
           );


### PR DESCRIPTION
With the latest version of Astro, the bundle uses `"` instead of `'`, so the current shim repleacer doesn't work. With this change we support both types of quotes (for old and new versions of Astro).

[Related issue](https://github.com/denoland/deno-astro-adapter/issues/53)
