### PR TITLE
ci: add npm publish workflow with trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish
+        run: npx npm@latest publish --provenance --access public


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that publishes to npm when a version tag (e.g. `0.5.1`) is pushed
- Uses OIDC-based trusted publishing — no `NPM_TOKEN` secret needed
- Ensures npm >= 11.5.1 via `npx npm@latest` for trusted publishing support

## Next steps
After merging, bump version to `0.5.1` and push a tag to test the automated publish.